### PR TITLE
samples: peripheral_hids: Register HIDS before enabling Bluetooth

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -191,6 +191,9 @@ Samples
 Bluetooth samples
 -----------------
 
+* :ref:`peripheral_hids_keyboard` and :ref:`peripheral_hids_mouse` samples register HID Service before Bluetooth is enabled (before calling the :c:func:`bt_enable` function).
+  The :c:func:`bt_gatt_service_register` function can no longer be called after enabling Bluetooth and before loading settings.
+
 * Removed:
 
   * The Bluetooth 3-wire coex sample because of the removal of the 3-wire implementation.

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -952,6 +952,8 @@ void main(void)
 		return;
 	}
 
+	hid_init();
+
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
@@ -959,8 +961,6 @@ void main(void)
 	}
 
 	printk("Bluetooth initialized\n");
-
-	hid_init();
 
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -773,6 +773,9 @@ void main(void)
 		}
 	}
 
+	/* DIS initialized at system boot with SYS_INIT macro. */
+	hid_init();
+
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
@@ -780,9 +783,6 @@ void main(void)
 	}
 
 	printk("Bluetooth initialized\n");
-
-	/* DIS initialized at system boot with SYS_INIT macro. */
-	hid_init();
 
 	k_work_init(&hids_work, mouse_handler);
 	k_work_init(&pairing_work, pairing_process);


### PR DESCRIPTION
Change prevents errors during boot. Registering GATT Services after enabling Bluetooth and before loading settings is no longer allowed in Zephyr.

Jira: NCSDK-20600