### PR TITLE
lib: edge_impulse: Add explicit dependency to zephyr_interface

### DIFF
--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -101,6 +101,7 @@ target_include_directories(edge_impulse INTERFACE
 target_link_libraries(edge_impulse INTERFACE ${EDGE_IMPULSE_LIBRARY})
 
 add_dependencies(edge_impulse
+                 zephyr_interface
                  edge_impulse_project
                  edge_impulse_project_download
 )


### PR DESCRIPTION
Add explicit dependency to zephyr_interface when building edge_impulse library. This dependency seems not to be ingerited from edge_impulse_project as it is build with ExternalProject_Add function.

Jira: NCSDK-20857