### PR TITLE
application: serial_lte_modem: Fix UART enable

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -191,13 +191,13 @@ static int uart_receive(void)
 {
 	int ret;
 
+	next_buf = uart_rx_buf[1];
 	ret = uart_rx_enable(uart_dev, uart_rx_buf[0], sizeof(uart_rx_buf[0]), UART_RX_TIMEOUT_US);
 	if (ret && ret != -EBUSY) {
 		LOG_ERR("UART RX failed: %d", ret);
 		(void)uart_send(FATAL_STR, sizeof(FATAL_STR) - 1);
 		return ret;
 	}
-	next_buf = uart_rx_buf[1];
 	at_buf_overflow = false;
 	at_buf_len = 0;
 


### PR DESCRIPTION
Next buffer is passed to UART as null if it is not set, before calling uart_rx_enable.