### PR TITLE
crypto: Isolated GCC-specific warning option for nrf_oberon

### DIFF
--- a/subsys/nrf_security/src/drivers/nrf_oberon/CMakeLists.txt
+++ b/subsys/nrf_security/src/drivers/nrf_oberon/CMakeLists.txt
@@ -48,10 +48,19 @@ add_library(oberon_psa_driver STATIC
 target_compile_options(oberon_psa_driver
   PRIVATE
     -Wno-uninitialized
-    -Wno-maybe-uninitialized
     -Wno-unused-variable
     -Wno-unused-function
 )
+
+# Clang does not support -Wno-maybe-uninitialized so the following
+# warning option is only used for GNU (GCC)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(oberon_psa_driver
+    PRIVATE
+      -Wno-maybe-uninitialized
+  )
+endif()
+
 
 target_include_directories(oberon_psa_driver
   PRIVATE


### PR DESCRIPTION
-This commit isolates usage of -Wno-maybe-uninitialized only for GNU
 enabled compiler (GCC) because Clang doesn't support it